### PR TITLE
Add all Slack Workplace owners and admins as CoC contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,15 @@ Jäsentemme monimuotoisuus ja erilaisuuden tervetulleeksi toivottaminen tekee yh
     - Älä käyttäydy epäkunnioittavasti muita kohtaan (vitsailu, vihjailu, väheksyvä asenne)
   - Uhkailu tai häirintä
   - Sopimaton huomio tai yhteydenotto. Älä tee kenenkään oloa epämukavaksi.
-  - Väkivalta, väkivallalla uhkailu tai väkivaltainen kielenkäyttö
+  - Väkivalta, väkivallalla uhkailu tai väkivaltainen kielenkäyttö.
 
 Saat kirjoittaa joko omalla nimelläsi tai nimimerkillä, joka on helposti tunnistettavissa nimimerkiksi. Myöskään profiilikuva ei ole pakollinen. Jos profiilikuvasi on kuitenkin kuva ihmisestä, sen tulisi olla kuva sinusta.
 
-Mikäli koet, että joku rikkoo käytössääntöjä joko sinua tai muita jäseniä kohtaan voit lähettää yksityisviestiä suoraan seuraaville käyttäjille:
-riku (Riku Rouvila) tai keksike (Cihan Bebek)
+Mikäli koet, että joku rikkoo käytössääntöjä joko sinua tai muita jäseniä kohtaan voit lähettää yksityisviestiä Koodiklinikan valvojille:
 
-tai lähettää myös sähköpostia osoitteeseen info@koodiklinikka.fi
+@riku @keksike @pinqvin @akx @ajk @jallu @pakastin @juhis @Kitsu @lallinuo @lauri @lauripiispanen @mariannesiren @maffe @n1ko @ochrons @pete @peritpatrio @ristohietal @trautonen
 
-Olemme paikalla sinun vuoksesi ja autamme mielellämme ongelmatilanteissa tai yhteisöömme liittyvissä kysymyksissä
+tai lähettää myös sähköpostia osoitteeseen info@koodiklinikka.fi.
 
-
-
-
-
-
-
-
-
-
-
- 
+Olemme paikalla sinun vuoksesi ja autamme mielellämme ongelmatilanteissa tai yhteisöömme liittyvissä kysymyksissä.
 


### PR DESCRIPTION
Folks were asking for the list of admins in the #yleinen channel. Added the CoC to the description and bookmarks but the list of admins wouldn't fit to either of those. Would this work?