### PR TITLE
Add a English translation of the code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,59 @@ tai lähettää myös sähköpostia osoitteeseen info@koodiklinikka.fi
 
 Olemme paikalla sinun vuoksesi ja autamme mielellämme ongelmatilanteissa tai yhteisöömme liittyvissä kysymyksissä
 
+## Koodiklinikka Code of Conduct in English
 
+Our goal is to provide a harassment-free, kind, and helpful community around
+programming topics to everyone regardless of gender, age, programming
+experience, sexual orientation, physical or mental health restrictions,
+appearance, ethnic background, or religion. We do not tolerate harassment of
+any kind. Sexual language is not acceptable in the community's events or
+communication channels. Users and sponsors of the community that violate these
+rules may be removed from the events and from community's other communication
+channels. Anyone who violates these rules may be expelled from the community
+without any right to be compensated for entrance, member, or other fees if the
+maintainers of the community so decide.
 
+Our main objective with Koodiklinikka has always been to provide a place where
+anyone can ask anything without fear of being judged, mocked, or harassed for
+their questions. We want to emphasize that there are no stupid questions and
+that every question deserves a complete, well-founded answer. Rarely is there
+one best answer for a question and there are usually many different solutions
+to one problem. Consider the needs of the person asking the question and how
+you can help them find a solution to their problem in a manner that fits the
+context. Avoid answers like "why don't you just do it like this?" and instead
+try to provide an answer that fits the situation the asker is in.  Our
+community is strengthened and enriched by our diverse members and acceptance
+of differences. We encourage diversity without exception and we hope that
+people from all different backgrounds join our community. It is vitally
+important for us that every member of our community feels like they can be
+their own selves when participating in our community.
 
+*Our expectations to you*
+- Be kind
+- Welcome everyone to participate in the discussion and other activity
+- Take care of fellow members of the community
+- Be helpful and try to uphold an atmosphere that keeps the threshold for
+  asking questions as low as possible
 
+*What we do not tolerate*
+- Behaviour or speech that can be interpreted as sexist, racist, homophobic,
+  transphobic, or otherwise discriminatory or offensive
+  - Do not use suggestive, derogatory, or inappropriate monikers or terms
+  - Do not behave disrespectfully towards others (e.g. making fun of someone,
+    making suggestive comments, being dismissive)
+- Bullying or harassment
+- Inappropriate attention or contact. Do not make anyone uncomfortable.
+- Violence, threatening with violence, or violent communication
 
+You can participate using your own name or with a nickname that is easily
+identifiable as a nickname. Uploading a profile picture is not mandatory. If
+your profile picture is of a person, that person should be you.
 
+If you feel that someone has violated the code of conduct against you or any
+other member of the community, send a private message on Slack to riku (Riku
+Rouvila) or keksike (Cihan Bebek), or contact us via email at
+info@koodiklinikka.fi
 
-
-
-
- 
-
+We are here for you and we are happy to help with any
+problems or questions regarding our community.


### PR DESCRIPTION
Adds a pretty direct English translation of the Finnish Code of Conduct text. This is needed because there are the occassional non-Finnish speaking new members joining Koodiklinikka and sometimes they need the Code of Conduct in English.

(tupsu did grammatical and semantical corrections to the text.)